### PR TITLE
doc: add read the docs configuration

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/source/conf.py


### PR DESCRIPTION
This configuration file is required for the `Read The Docs` project setup.
Note that no documentation regarding the code has been done yet.

GH: #8