### PR TITLE
doc/12-fix-badges-and-editor-config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ max_line_length = 79
 
 [*.{yml,yaml}]
 indent_size = 2
+
+[*.rst]
+indent_size = 3

--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,22 @@
 CVW22 Operations Officer
 ========================
 
-.. image:: https://img.shields.io/github/license/niklasg08/cvw22-operations-officer
+|license| |last-commit| |release| |ci| |docs|
+
+.. |license| image:: https://img.shields.io/github/license/niklasg08/cvw22-operations-officer
    :alt: GitHub License
-.. image:: https://img.shields.io/github/last-commit/niklasg08/cvw22-operations-officer
+   :target: https://github.com/niklasg08/cvw22-operations-officer/blob/main/LICENSE
+.. |last-commit| image:: https://img.shields.io/github/last-commit/niklasg08/cvw22-operations-officer
    :alt: GitHub last commit
-.. image:: https://img.shields.io/github/v/release/niklasg08/cvw22-operations-officer
+.. |release| image:: https://img.shields.io/github/v/release/niklasg08/cvw22-operations-officer
    :alt: GitHub Release
-.. image:: https://img.shields.io/github/actions/workflow/status/niklasg08/cvw22-operations-officer/python-ci.yml?label=CI
+   :target: https://github.com/niklasg08/cvw22-operations-officer/releases
+.. |ci| image:: https://img.shields.io/github/actions/workflow/status/niklasg08/cvw22-operations-officer/python-ci.yml?label=CI
    :alt: GitHub Actions Workflow Status
-.. image:: https://img.shields.io/readthedocs/cvw22-operations-officer
+   :target: https://github.com/niklasg08/cvw22-operations-officer/actions/workflows/python-ci.yml
+.. |docs| image:: https://img.shields.io/readthedocs/cvw22-operations-officer
    :alt: Read the Docs
+   :target: https://cvw22-operations-officer.readthedocs.io/en/latest/index.html
 
 The CVW22 Operations Officer is a python written discord bot. It's used to simplify and automate operations on the
 vCVW22 discord server. The configuration, deployment and maintenance is straight-forward and offers perfect flexibility


### PR DESCRIPTION
The badges in the `README.rst` have been improved since GitHub displayed them wrong. Additionally, the `.editorconfig` was updated to specify the `indent-size` of rst-files.

GH: #12 